### PR TITLE
Removed finish call

### DIFF
--- a/ZabbixProxyDB.pm
+++ b/ZabbixProxyDB.pm
@@ -49,7 +49,6 @@ sub execute_query {
 				$servers{$ret_arr[1]} = $ret_arr[0];
 #                               print $ret_arr[0].' '.$ret_arr[1]."\n";
 			}
-			$sth->finish();
 		}
 		else {
 			print STDERR "Cannot execute query.\n";


### PR DESCRIPTION
https://metacpan.org/pod/DBI#finish
Adding calls to finish after loop that fetches all rows is a common mistake, don't do it, it can mask genuine problems like uncaught fetch errors.

When all the data has been fetched from a SELECT statement, the driver will automatically call finish for you. So you should not call it explicitly except when you know that you've not fetched all the data from a statement handle and the handle won't be destroyed soon.
