### PR TITLE
fix collector crush if other items exists on host

### DIFF
--- a/rabbitmq/rmq_data_collect.pl
+++ b/rabbitmq/rmq_data_collect.pl
@@ -155,7 +155,7 @@ sub build_json_object # func builds hash with all unique RMQ API paths in keys a
 	{	
 		$key =~ m/.*\[([^:]+):([^:]+):(.*)\]/;
 		my $rmqPath = $2;
-		if (!grep(/^$rmqPath$/,@rmqPaths))
+		if (defined $rmqPath && !grep(/^$rmqPath$/,@rmqPaths))
 		{
 			my $jsonObj = get_json_object_from_rmq($rmqHosts,$rmqPath);
 			$jsonObj{$rmqPath} = map_rmq_elements($rmqPath,$jsonObj);


### PR DESCRIPTION
If item key is not prepared for rmq monitoring $rmqPath is empy and script exit
